### PR TITLE
add extern "C" macro for C++

### DIFF
--- a/src/sfd.h
+++ b/src/sfd.h
@@ -10,6 +10,10 @@
 
 #define SFD_VERSION "0.1.0"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 typedef struct {
   const char *title;
   const char *path;
@@ -21,5 +25,9 @@ typedef struct {
 const char* sfd_get_error(void);
 const char* sfd_open_dialog(sfd_Options *opt);
 const char* sfd_save_dialog(sfd_Options *opt);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif


### PR DESCRIPTION
Including "sfd.h" in a c++ project gives me linker error because the extern "c" guard is missing. 